### PR TITLE
Adiciona healthCheck na aplicação: status, uptime, latência, database: "up"

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
   
 # Sistema de Gerenciamento de Tarefas
 
+[![Build Status](https://github.com/LaylaJHB/To-Do-List_Backend-Node.Js_Desafio/actions/workflows/test.yml/badge.svg)](https://github.com/LaylaJHB/To-Do-List_Backend-Node.Js_Desafio/actions)
+
 ## 🌟 Destaques deste projeto Backend:
 
 - ✅ Documentação interativa via Postman.
@@ -187,6 +189,9 @@ Arquitetura de software em 3 camadas (3-tiers):
 * Controller: camada de interface, comunicação.
 * Bussiness: camada lógica, principal
 * Database: armazenamento e gerenciamento dos dados/informações
+
+![Arquitetura Detalhada]('')
+
 
 ---
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,10 +1,12 @@
 import express, {Express} from 'express'
 import cors from 'cors'
+import healthRouter from "./controller/routes/healthRouter";
 
 export const app: Express = express()
 
 app.use(express.json())
 app.use(cors())
+app.use(healthRouter);
 
 app.listen(process.env.PORT || 3003, () => {
     console.log(`Server running on port ${process.env.PORT || 3003}`)

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,12 +1,12 @@
 import express, {Express} from 'express'
 import cors from 'cors'
-import healthRouter from "./controller/routes/healthRouter";
 
 export const app: Express = express()
 
 app.use(express.json())
 app.use(cors())
-app.use(healthRouter);
+
+
 
 app.listen(process.env.PORT || 3003, () => {
     console.log(`Server running on port ${process.env.PORT || 3003}`)

--- a/src/controller/routes/healthRouter.ts
+++ b/src/controller/routes/healthRouter.ts
@@ -1,17 +1,14 @@
-// src/routes/health.ts
 import { Router, Request, Response } from "express";
-import knex from "knex"; // ou sua instância de conexão
+import { BaseDatabase } from "../../data/mySQL/BaseDatabase";
 
 const router = Router();
 
-router.get("/health", async (req: Request, res: Response) => {
-  // 1) Verifica tempo de resposta do servidor
+router.get("/", async (req: Request, res: Response) => {
   const start = Date.now();
-
-  // 2) Verifica conexão com o DB
   let dbStatus = "up";
+
   try {
-    await knex.raw("SELECT 1"); // ou prisma.$queryRaw`SELECT 1`
+    await BaseDatabase.connection.raw("SELECT 1");
   } catch {
     dbStatus = "down";
   }
@@ -20,7 +17,7 @@ router.get("/health", async (req: Request, res: Response) => {
 
   res.status(200).json({
     status: "ok",
-    uptime: process.uptime(),       // segundos desde o start do processo
+    uptime: process.uptime(),
     latency: `${latency}ms`,
     database: dbStatus
   });

--- a/src/controller/routes/healthRouter.ts
+++ b/src/controller/routes/healthRouter.ts
@@ -1,0 +1,29 @@
+// src/routes/health.ts
+import { Router, Request, Response } from "express";
+import knex from "knex"; // ou sua instância de conexão
+
+const router = Router();
+
+router.get("/health", async (req: Request, res: Response) => {
+  // 1) Verifica tempo de resposta do servidor
+  const start = Date.now();
+
+  // 2) Verifica conexão com o DB
+  let dbStatus = "up";
+  try {
+    await knex.raw("SELECT 1"); // ou prisma.$queryRaw`SELECT 1`
+  } catch {
+    dbStatus = "down";
+  }
+
+  const latency = Date.now() - start;
+
+  res.status(200).json({
+    status: "ok",
+    uptime: process.uptime(),       // segundos desde o start do processo
+    latency: `${latency}ms`,
+    database: dbStatus
+  });
+});
+
+export default router;

--- a/src/data/mySQL/BaseDatabase.ts
+++ b/src/data/mySQL/BaseDatabase.ts
@@ -6,7 +6,7 @@ dotenv.config()
 export class BaseDatabase {
 
 
-   protected static connection = knex({
+   public static connection = knex({
       client: "mysql2",
       connection: {
          host: process.env.DB_HOST,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
 import { app } from "./app"
 import { userRouter } from "./controller/routes/userRouter"
 import { taskRouter } from "./controller/routes/taskRouter"
+import healthRouter from "./controller/routes/healthRouter";
 
 app.use('/user', userRouter )
 app.use('/task', taskRouter )
+app.use('/health', healthRouter);


### PR DESCRIPTION
🔎 Resposta detalhada do /health

{
  "status": "ok",
  "uptime": 145.9516021,
  "latency": "448ms",
  "database": "up"
}

✅ status: "ok"
Indica que a aplicação está rodando normalmente.


⏱️ uptime: 145.9516021
Tempo (em segundos) desde que o servidor Node.js foi iniciado.

Útil para identificar se a aplicação está reiniciando com frequência, o que pode indicar falhas.

⚡ latency: "448ms"
Tempo (em milissegundos) que o servidor levou para processar essa requisição /health.

Valores baixos (geralmente < 500ms) indicam boa performance da API.

Se esse valor estiver alto com frequência, pode ser indício de lentidão no banco ou no servidor.

🛢️ database: "up"
Indica que a conexão com o banco de dados foi bem-sucedida.

Se falhar, o valor muda para "down".

✅ Conclusão
Posteriormente é possível fazer uso com ferramentas de monitoramento, como UptimeRobot, Vercel checks, New Relic ou Datadog. Possível gerar alertas (ex: banco caiu, app travou)